### PR TITLE
Revert "Add support for multistage build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
-# Multistage build 
-FROM alpine:3 AS builder
-WORKDIR /app
-COPY . .
-RUN apk add --update --no-cache npm \
-    && npm ci --only=production
-
-
 # see hooks/build and hooks/.config
 ARG BASE_IMAGE_PREFIX
-FROM ${BASE_IMAGE_PREFIX}alpine:3
+FROM ${BASE_IMAGE_PREFIX}alpine
 
 # see hooks/post_checkout
 ARG ARCH
@@ -16,10 +8,12 @@ COPY qemu-${ARCH}-static /usr/bin
 
 LABEL maintainer="S. Saeid Hosseini <sayidhosseini@hotmail.com>"
 
-RUN apk add --update --no-cache nodejs curl
+RUN apk add --update --no-cache npm curl
 
 WORKDIR /usr/src/authentiq
-COPY --from=builder /app/ ./
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
 
 EXPOSE 2000
-CMD ["node", "./bin/www"]
+CMD ["npm", "start"]


### PR DESCRIPTION
Reverts SayidHosseini/authentiq#3

This is not working on ARM platforms (Tested on arm32v7 and arm64v8). Apparantly it feels like it is executing x86_64 on ARM!

Complaints about:
```
\standard_init_linux.go:211: exec user process caused "exec format error"
```